### PR TITLE
 Updates to enable basic single tone output 

### DIFF
--- a/AD9910.cpp
+++ b/AD9910.cpp
@@ -80,8 +80,8 @@ void AD9910::begin(unsigned long ref, uint8_t divider){
   reg_t cfr2;
   cfr2.addr = 0x01;           // This was 0x02 which would never work
   cfr2.data.bytes[0] = 0x20;  // AMH Change back to default
-  cfr2.data.bytes[1] = 0x08;  // AMH PDCLK is enbaled, but doesn't need to be long term.  Use it for debugging, then turn it off.
-  cfr2.data.bytes[2] = 0x00;  // sync_clk pin disabled; not used
+  cfr2.data.bytes[1] = 0x00;  // PDCLK disabled; not used
+  cfr2.data.bytes[2] = 0x00;  // SYNC_CLK pin disabled; not used
   cfr2.data.bytes[3] = 0x01;  // enable ASF from single tone profile
 
   reg_t cfr3;
@@ -100,6 +100,7 @@ void AD9910::begin(unsigned long ref, uint8_t divider){
   reg_t auxdac;
   auxdac.addr = 0x03;
   auxdac.data.bytes[0] = 0xFF; // AMH: This will push to the part to its max specified full scale output current of 31.6 mA with an RSET of 10k
+  //auxdac.data.bytes[0] = 0x3F;    // AMH: Dial back to default instead
 
   writeRegister(cfr2);
   writeRegister(cfr3);
@@ -141,8 +142,8 @@ void AD9910::setFreq(uint32_t freq, uint8_t profile){
   payload.bytes = 8;
   payload.addr = 0x0E + profile;
   payload.data.dwords[0] =  _ftw[profile];
-  payload.data.words[3] = 0x0000; // Phase = 0
-  payload.data.words[4] = _asf[profile];
+  payload.data.words[2] = 0x0000; // Phase = 0
+  payload.data.words[3] = _asf[profile];
 	// actually writes to register
   writeRegister(payload);
   update();
@@ -170,8 +171,8 @@ void AD9910::setAmp(double scaledAmp, byte profile){
    payload.bytes = 8;
    payload.addr = 0x0E + profile;
    payload.data.dwords[0] =  _ftw[profile];
-   payload.data.words[3] = 0x0000; // Phase = 0
-   payload.data.words[4] = _asf[profile];
+   payload.data.words[2] = 0x0000; // Phase = 0
+   payload.data.words[3] = _asf[profile];
 	// actually writes to register
   writeRegister(payload);
   update();

--- a/AD9910.cpp
+++ b/AD9910.cpp
@@ -78,11 +78,11 @@ void AD9910::begin(unsigned long ref, uint8_t divider){
   delay(1);
 
   reg_t cfr2;
-  cfr2.addr = 0x02;
-  cfr2.data.bytes[0] = 0x02;
-  cfr2.data.bytes[1] = 0x08;
-  cfr2.data.bytes[2] = 0x00;  // sync_clk pin disabled; not used
-  cfr2.data.bytes[3] = 0x01;  // enable ASF
+  cfr2.addr = 0x01;
+  cfr2.data.bytes[0] = 0x20;
+  cfr2.data.bytes[1] = 0x00;  // PDCLK disabled; not used
+  cfr2.data.bytes[2] = 0x00;  // SYNC_CLK pin disabled; not used
+  cfr2.data.bytes[3] = 0x01;  // enable ASF from single tone profile
 
   reg_t cfr3;
   cfr3.addr = 0x02;
@@ -92,7 +92,16 @@ void AD9910::begin(unsigned long ref, uint8_t divider){
     cfr3.data.bytes[3] = 0x07;
   } else {
     cfr3.data.bytes[1] = 0x41;    // enable PLL
-    cfr3.data.bytes[3] = 0x05;
+    // Search for closest VCO
+    uint32_t err = ULONG_MAX;
+    uint8_t vco = 0;
+    for (int i = 0; i < 6; i++){
+      if (abs(_refClk-_vcoMid[i]) < err){
+        vco = i;
+      }
+    }
+    
+    cfr3.data.bytes[3] = vco;
   }
   cfr3.data.bytes[2] = 0x3F;
 
@@ -107,7 +116,6 @@ void AD9910::begin(unsigned long ref, uint8_t divider){
 
   delay(1);
 
-  _profileModeOn = false; //profile mode is disabled by default
   _OSKon = false; //OSK is disabled by default
   _activeProfile = 0;
 
@@ -140,17 +148,16 @@ void AD9910::setFreq(uint32_t freq, uint8_t profile){
   reg_t payload;
   payload.bytes = 8;
   payload.addr = 0x0E + profile;
-  payload.data.block[0] =  _ftw[profile];
-  // need to write a way around updating the amplitude/phase words to default here...
-  //
-  payload.data.block[1] = 0x3FFF0000;
+  payload.data.dwords[0] =  _ftw[profile];
+  payload.data.words[2] = 0x0000; // Phase = 0
+  payload.data.words[3] = _asf[profile];
 	// actually writes to register
-  //AD9910::writeRegister(CFR1Info, CFR1);
   writeRegister(payload);
   update();
+
+  selectProfile(profile);
 }
 
-/*
 void AD9910::setAmp(double scaledAmp, byte profile){
    if (profile > 7) {
         return; //invalid profile, return without doing anything
@@ -166,14 +173,20 @@ void AD9910::setAmp(double scaledAmp, byte profile){
       _asf[profile]=0; //write min value
    }
 
-   AD9910::writeAmp(_asf[profile],profile);
+   reg_t payload;
+   payload.bytes = 8;
+   payload.addr = 0x0E + profile;
+   payload.data.dwords[0] =  _ftw[profile];
+   payload.data.words[2] = 0x0000; // Phase = 0
+   payload.data.words[3] = _asf[profile];
+	// actually writes to register
+  writeRegister(payload);
+  update();
 
+  selectProfile(profile);
 }
 
-void AD9910::setAmp(double scaledAmp){
-  AD9910::setAmp(scaledAmp,0);
-}
-
+/*
 void AD9910::setAmpdB(double scaledAmpdB, byte profile){
   if (profile > 7) {
         return; //invalid profile, return without doing anything
@@ -277,26 +290,6 @@ void AD9910::setFTW(unsigned long ftw, byte profile){
 //   AD9910::setFTW(ftw,0);
 // }
 
-//Enable the profile select mode
-void AD9910::enableProfileMode() {
-  //write 0x01, byte 23 high
-  _profileModeOn = true;
-  byte registerInfo[] = {0x01, 4};
-  byte data[] = {0x00, 0x80, 0x09, 0x00};
-  AD9910::writeRegister(registerInfo, data);
-  AD9910::update();
-}
-
-//Disable the profile select mode
-void AD9910::disableProfileMode() {
-  //write 0x01, byte 23 low
-  _profileModeOn = false;
-  byte registerInfo[] = {0x01, 4};
-  byte data[] = {0x00, 0x00, 0x09, 0x00};
-  AD9910::writeRegister(registerInfo, data);
-  AD9910::update();
-}
-
 //enable OSK
 void AD9910::enableOSK(){
   //write 0x00, byte 8 high
@@ -315,11 +308,6 @@ void AD9910::disableOSK(){
   byte data[] = {0x00, 0x01, 0x00, 0x08};
   AD9910::writeRegister(registerInfo, data);
   AD9910::update();
-}
-
-//return boolean indicating if profile select mode is activated
-boolean AD9910::getProfileSelectMode() {
-  return _profileModeOn;
 }
 
 //return boolean indicating if OSK mode is activated
@@ -342,6 +330,8 @@ void AD9910::disableSyncClck() {
   AD9910::writeRegister(registerInfo, data);
   AD9910::update();
 }
+
+*/
 
 void AD9910::selectProfile(byte profile){
   //Possible improvement: write PS pin states all at once using register masks
@@ -372,7 +362,6 @@ void AD9910::selectProfile(byte profile){
 byte AD9910::getProfile() {
   return _activeProfile;
 }
-*/
 
 // Writes SPI to particular register.
 //      registerInfo is a 2-element array which contains [register, number of bytes]

--- a/AD9910.h
+++ b/AD9910.h
@@ -99,6 +99,7 @@ class AD9910
     //void writeAmp(long ampScaleFactor, uint8_t profile);
     // DDS frequency resolution
     double RESOLUTION;// = 4294967296; // sets resolution to 2^32 = 32 bits. Using type double to avoid confusion with integer division...
+    const uint32_t _vcoMid[6] = { 440000000, 505000000, 600000000, 740000000, 825000000, 985000000 };
 };
 
 #endif

--- a/AD9910.h
+++ b/AD9910.h
@@ -27,7 +27,8 @@ class AD9910
 {
   typedef union {
     uint8_t bytes[8] = {0};
-    uint32_t block[2];
+    uint16_t words[4];
+    uint32_t dwords[2];
   } data_t;
 
   typedef struct {
@@ -54,9 +55,9 @@ class AD9910
     unsigned long getFTW(uint8_t profile = 0);
     // Sets frequency tuning word
     void setFTW(unsigned long ftw, uint8_t profile = 0);
-/*  *********************** to implement later ***************
     //write scaled amplitude for the selected profile
     void setAmp(double scaledAmp, uint8_t profile = 0);
+/*  *********************** to implement later ***************
     void setAmpdB(double scaledAmpdB, uint8_t profile = 0);
     // Gets current amplitude
     double getAmp(uint8_t profile = 0);
@@ -66,27 +67,21 @@ class AD9910
     unsigned long getASF(uint8_t profile = 0);
     // places DDS in linear sweep mode
     //void linearSweep(unsigned long, unsigned long, unsigned long, byte, unsigned long, byte);
-    //enable profile mode
-    void enableProfileMode();
-    //disable profile mode
-    void disableProfileMode();
     //enable OSK
     void enableOSK();
     //disable OSK
     void disableOSK();
-    //Get profile mode status
-    bool getProfileSelectMode();
     //Get OSK mode status
     bool getOSKMode();
     //enable the Sync Clck output
     void enableSyncClck();
     //disable the Sync Clck output
     void disableSyncClck();
+*/
     //Change active profile mode:
     void selectProfile(byte);
     //Get currently active profile
     uint8_t getProfile();
-*/
     void writeRegister(reg_t payload);
 
   private:
@@ -99,7 +94,7 @@ class AD9910
     double _scaledAmp[8], _scaledAmpdB[8];
     uint8_t _activeProfile;
     // Instance variables to keep track of the DDS mode:
-    bool _profileModeOn, _OSKon;
+    bool _OSKon;
     // write amplitude tuning word to device
     //void writeAmp(long ampScaleFactor, uint8_t profile);
     // DDS frequency resolution

--- a/AD9910.h
+++ b/AD9910.h
@@ -27,7 +27,8 @@ class AD9910
 {
   typedef union {
     uint8_t bytes[8] = {0};
-    uint32_t block[2];
+    uint16_t words[4];
+    uint32_t dwords[2];
   } data_t;
 
   typedef struct {
@@ -54,9 +55,9 @@ class AD9910
     unsigned long getFTW(uint8_t profile = 0);
     // Sets frequency tuning word
     void setFTW(unsigned long ftw, uint8_t profile = 0);
-/*  *********************** to implement later ***************
     //write scaled amplitude for the selected profile
     void setAmp(double scaledAmp, uint8_t profile = 0);
+/*  *********************** to implement later ***************
     void setAmpdB(double scaledAmpdB, uint8_t profile = 0);
     // Gets current amplitude
     double getAmp(uint8_t profile = 0);
@@ -66,27 +67,21 @@ class AD9910
     unsigned long getASF(uint8_t profile = 0);
     // places DDS in linear sweep mode
     //void linearSweep(unsigned long, unsigned long, unsigned long, byte, unsigned long, byte);
-    //enable profile mode
-    void enableProfileMode();
-    //disable profile mode
-    void disableProfileMode();
     //enable OSK
     void enableOSK();
     //disable OSK
     void disableOSK();
-    //Get profile mode status
-    bool getProfileSelectMode();
     //Get OSK mode status
     bool getOSKMode();
     //enable the Sync Clck output
     void enableSyncClck();
     //disable the Sync Clck output
     void disableSyncClck();
+*/
     //Change active profile mode:
     void selectProfile(byte);
     //Get currently active profile
     uint8_t getProfile();
-*/
     void writeRegister(reg_t payload);
 
   private:
@@ -99,11 +94,12 @@ class AD9910
     double _scaledAmp[8], _scaledAmpdB[8];
     uint8_t _activeProfile;
     // Instance variables to keep track of the DDS mode:
-    bool _profileModeOn, _OSKon;
+    bool _OSKon;
     // write amplitude tuning word to device
     //void writeAmp(long ampScaleFactor, uint8_t profile);
     // DDS frequency resolution
     double RESOLUTION;// = 4294967296; // sets resolution to 2^32 = 32 bits. Using type double to avoid confusion with integer division...
+    const uint32_t _vcoMid[6] = { 440000000, 505000000, 600000000, 740000000, 825000000, 985000000 };
 };
 
 #endif


### PR DESCRIPTION
These are changes I found necessary to get basic single tone mode working on an eBay AD9910 DDS Eval Board.  I believe the config changes still allow this code to be generic.  But one particular change seems absolutely necessary: CFR2 was set with an address of 0x02 and it should be 0x01.